### PR TITLE
font support

### DIFF
--- a/public/modules/default-theme/public/views/partials/lib/hooks/hook_theme_variables.liquid
+++ b/public/modules/default-theme/public/views/partials/lib/hooks/hook_theme_variables.liquid
@@ -3,6 +3,17 @@
   Provides the color scheme and other design tokens that define a default theme.
 {% endcomment %}
 
+{% capture theme_headscripts %}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Mulish:ital,wght@0,400;0,500;1,400&display=swap" rel="stylesheet">
+  <style>
+    :root {
+      --pos-fonts-default: "Mulish"
+    }
+  </style>
+{% endcapture %}
+
 {% parse_json theme_variables %}
 {
   "theme": "theme-default",
@@ -222,7 +233,8 @@
       "value": "255, 233, 200",
       "isEditable": false
     }
-  ]
+  ],
+  "headscripts": "{{ theme_headscripts | escape_javascript }}"
 }
 {% endparse_json %}
 


### PR DESCRIPTION
# Description

We replaced the hardcoded custom font with `pos-fonts-default` variable in the component library module, so themes can implement it based on the project requirements.
The default fallback font comes from the default tailwind config (sans-serif).
In the future we'll extend the font support by adding new font variables for headlines and other typography elements (`pos-fonts-primary`, `pos-fonts-secondary`, etc with a fallback to `pos-fonts-default`)

The default theme (which is a submodule of the Theme Manager) implements the above by adding `Mulish` from google fonts and setting it as `--pos-fonts-default`.

## Issue ticket number and link
https://trello.com/c/iaijIFpd

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged and published in downstream modules
