### PR TITLE
Use default theme if theme settings is missing

### DIFF
--- a/public/views/partials/lib/queries/theme/get_main.liquid
+++ b/public/views/partials/lib/queries/theme/get_main.liquid
@@ -1,4 +1,6 @@
 {% liquid
   function main_theme = 'modules/core/lib/queries/variable/get', name: 'THEME'
+
+  assign main_theme = main_theme | default: 'theme-default'
   return main_theme
 %}

--- a/public/views/partials/lib/queries/theme/get_variables.liquid
+++ b/public/views/partials/lib/queries/theme/get_variables.liquid
@@ -5,19 +5,19 @@
   assign theme = theme | default: main_theme
 
   if theme_variables_implementations.size == 0
-    log 'No implementation for theme variables in lib/queries/theme/get_theme_variables', type: 'theme_manager'
+    log 'No implementation for theme variables in lib/queries/theme/get_variables', type: 'theme_manager'
     return nil
   endif
 
   if theme == blank
-    log 'No selected theme in lib/queries/theme/get_theme_variables', type: 'theme_manager'
+    log 'No selected theme in lib/queries/theme/get_variables', type: 'theme_manager'
     return nil
   endif
 
   assign theme_variables = theme_variables_implementations | array_detect: theme: theme
 
   if theme_variables == blank
-    log 'No theme_variables implementation for selected theme in lib/queries/theme/get_theme_variables', type: 'theme_manager'
+    log 'No theme_variables implementation for selected theme in lib/queries/theme/get_variables', type: 'theme_manager'
     return nil
   endif
 


### PR DESCRIPTION
# Description

Use default theme in `lib/queries/theme/get_main` as a fallback if `THEME` variable is missing.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged and published in downstream modules
